### PR TITLE
Add an option to append the maximum enchantment level.

### DIFF
--- a/src/main/java/me/b0iizz/advancednbttooltip/config/ConfigManager.java
+++ b/src/main/java/me/b0iizz/advancednbttooltip/config/ConfigManager.java
@@ -277,4 +277,11 @@ public class ConfigManager {
 	public static HudTooltipZIndex getHudTooltipZIndex() {
 		return config.hud.hudTooltipZ;
 	}
+
+	/**
+	 * @return true when the maximum enchantment level should be appended
+	 */
+	public static boolean isShowMaxEnchantmentLevel() {
+		return config.misc.showMaxEnchantmentLevel;
+	}
 }

--- a/src/main/java/me/b0iizz/advancednbttooltip/config/ModConfig.java
+++ b/src/main/java/me/b0iizz/advancednbttooltip/config/ModConfig.java
@@ -53,6 +53,10 @@ public class ModConfig extends PartitioningSerializer.GlobalData {
 	@ConfigEntry.Gui.TransitiveObject
 	HudConfig hud = new HudConfig();
 
+	@ConfigEntry.Category("nbt_misc")
+	@ConfigEntry.Gui.TransitiveObject
+	MiscConfig misc = new MiscConfig();
+
 	/**
 	 * The Category of the config containing all general options
 	 *
@@ -198,6 +202,22 @@ public class ModConfig extends PartitioningSerializer.GlobalData {
 		@ConfigEntry.Gui.EnumHandler(option = ConfigEntry.Gui.EnumHandler.EnumDisplayOption.BUTTON)
 		@ConfigEntry.Gui.Tooltip
 		HudTooltipZIndex hudTooltipZ = HudTooltipZIndex.TOP;
+
+	}
+
+	/**
+	 * The Category of the config containing all general options
+	 *
+	 * @author Rooftop Joe
+	 */
+	@Config(name = "nbt_misc")
+	public static class MiscConfig implements ConfigData {
+
+		/**
+		 * See In-game description.
+		 */
+		@ConfigEntry.Gui.Tooltip
+		boolean showMaxEnchantmentLevel = true;	
 
 	}
 }

--- a/src/main/java/me/b0iizz/advancednbttooltip/mixin/EnchantmentMixin.java
+++ b/src/main/java/me/b0iizz/advancednbttooltip/mixin/EnchantmentMixin.java
@@ -1,0 +1,55 @@
+/*	MIT License
+	
+	Copyright (c) 2020-present b0iizz
+	
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+	
+	The above copyright notice and this permission notice shall be included in all
+	copies or substantial portions of the Software.
+	
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+	SOFTWARE.
+*/
+package me.b0iizz.advancednbttooltip.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.fabricmc.api.Environment;
+import net.fabricmc.api.EnvType;
+
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.text.Text;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.TranslatableText;
+
+import me.b0iizz.advancednbttooltip.config.ConfigManager;
+
+@Mixin(Enchantment.class)
+@Environment(EnvType.CLIENT)
+public abstract class EnchantmentMixin {
+
+	@Shadow
+	public abstract int getMaxLevel();
+
+	@Inject(method = "Lnet/minecraft/enchantment/Enchantment;getName(I)Lnet/minecraft/text/Text;", at = @At(value = "TAIL"), locals = LocalCapture.CAPTURE_FAILHARD)
+	private void advancednbttooltip$appendMaxEnchantmentLevel(int level, CallbackInfoReturnable<Text> info, MutableText enchantmentName) { 
+		if (ConfigManager.isShowMaxEnchantmentLevel() && (this.getMaxLevel() > 1)) {
+			enchantmentName.append("/").append(new TranslatableText("enchantment.level." + this.getMaxLevel()));
+		}
+	}
+}

--- a/src/main/resources/advancednbttooltip.mixins.json
+++ b/src/main/resources/advancednbttooltip.mixins.json
@@ -6,6 +6,7 @@
   "mixins": [
   ],
   "client": [
+  	"EnchantmentMixin",
 	"ItemStackMixin",
 	"ScreenMixin"
   ],

--- a/src/main/resources/assets/advancednbttooltip/lang/en_au.json
+++ b/src/main/resources/assets/advancednbttooltip/lang/en_au.json
@@ -79,6 +79,9 @@
 	"text.advancednbttooltip.hideflag.can_place": "placeability on blocks",
 	"text.advancednbttooltip.hideflag.additional": "additional tooltips",
 	"text.advancednbttooltip.hideflag.dye": "dyed color",
+	"text.autoconfig.advancednbttooltip.category.nbt_misc": "Miscellaneous",
+	"text.autoconfig.advancednbttooltip.option.misc.showMaxEnchantmentLevel": "Show maximum ennchantment level",
+	"text.autoconfig.advancednbttooltip.option.misc.showMaxEnchantmentLevel.@Tooltip": "Adds the maximum enchantment level next to each enchantment.",
 	"category.advancednbttooltip.keys": "Advanced NBT Tooltips",
 	"key.advancednbttooltip.openConfig": "Open Advanced NBT Tooltips Config"
 }

--- a/src/main/resources/assets/advancednbttooltip/lang/en_ca.json
+++ b/src/main/resources/assets/advancednbttooltip/lang/en_ca.json
@@ -79,6 +79,9 @@
 	"text.advancednbttooltip.hideflag.can_place": "placeability on blocks",
 	"text.advancednbttooltip.hideflag.additional": "additional tooltips",
 	"text.advancednbttooltip.hideflag.dye": "dyed color",
+	"text.autoconfig.advancednbttooltip.category.nbt_misc": "Miscellaneous",
+	"text.autoconfig.advancednbttooltip.option.misc.showMaxEnchantmentLevel": "Show maximum ennchantment level",
+	"text.autoconfig.advancednbttooltip.option.misc.showMaxEnchantmentLevel.@Tooltip": "Adds the maximum enchantment level next to each enchantment.",
 	"category.advancednbttooltip.keys": "Advanced NBT Tooltips",
 	"key.advancednbttooltip.openConfig": "Open Advanced NBT Tooltips Config"
 }

--- a/src/main/resources/assets/advancednbttooltip/lang/en_gb.json
+++ b/src/main/resources/assets/advancednbttooltip/lang/en_gb.json
@@ -79,6 +79,9 @@
 	"text.advancednbttooltip.hideflag.can_place": "placeability on blocks",
 	"text.advancednbttooltip.hideflag.additional": "additional tooltips",
 	"text.advancednbttooltip.hideflag.dye": "dyed color",
+	"text.autoconfig.advancednbttooltip.category.nbt_misc": "Miscellaneous",
+	"text.autoconfig.advancednbttooltip.option.misc.showMaxEnchantmentLevel": "Show maximum ennchantment level",
+	"text.autoconfig.advancednbttooltip.option.misc.showMaxEnchantmentLevel.@Tooltip": "Adds the maximum enchantment level next to each enchantment.",
 	"category.advancednbttooltip.keys": "Advanced NBT Tooltips",
 	"key.advancednbttooltip.openConfig": "Open Advanced NBT Tooltips Config"
 }

--- a/src/main/resources/assets/advancednbttooltip/lang/en_us.json
+++ b/src/main/resources/assets/advancednbttooltip/lang/en_us.json
@@ -79,6 +79,9 @@
 	"text.advancednbttooltip.hideflag.can_place": "placeability on blocks",
 	"text.advancednbttooltip.hideflag.additional": "additional tooltips",
 	"text.advancednbttooltip.hideflag.dye": "dyed color",
+	"text.autoconfig.advancednbttooltip.category.nbt_misc": "Miscellaneous",
+	"text.autoconfig.advancednbttooltip.option.misc.showMaxEnchantmentLevel": "Show maximum ennchantment level",
+	"text.autoconfig.advancednbttooltip.option.misc.showMaxEnchantmentLevel.@Tooltip": "Adds the maximum enchantment level next to each enchantment.",
 	"category.advancednbttooltip.keys": "Advanced NBT Tooltips",
 	"key.advancednbttooltip.openConfig": "Open Advanced NBT Tooltips Config"
 }


### PR DESCRIPTION
This partly solves #31. Note that I've implemented this as a separate option in the config rather than a toggle. I see no real reason to use those for anything other than the JSON-specified data, other than to keep options like this on the same screen as those, but perhaps that would be confusing for users who find themselves in the middle of baked-in stuff and JSON stuff.

The other half of that ticket I would like to approach the same way in a future PR.