### PR TITLE
Update to 1.19.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.19
-	yarn_mappings=1.19+build.1
-	loader_version=0.14.6
+	minecraft_version=1.19.3
+	yarn_mappings=1.19.3+build.5
+	loader_version=0.14.13
 
 # Mod Properties
 	mod_version = 1.8.2
@@ -13,6 +13,6 @@ org.gradle.jvmargs=-Xmx4G
 	archives_base_name = advanced-nbt-tooltip
 
 # Dependencies
-	fabric_version=0.55.1+1.19
+	fabric_version=0.73.0+1.19.3
 	cloth_version=7.0.73
 	modmenu_version=4.0.4

--- a/src/main/java/me/b0iizz/advancednbttooltip/api/impl/builtin/BuiltInAxolotlVariantFactory.java
+++ b/src/main/java/me/b0iizz/advancednbttooltip/api/impl/builtin/BuiltInAxolotlVariantFactory.java
@@ -49,7 +49,7 @@ public class BuiltInAxolotlVariantFactory implements TooltipFactory {
 
 		int id = tag.getInt(AxolotlEntity.VARIANT_KEY);
 
-		AxolotlEntity.Variant variant = AxolotlEntity.Variant.VARIANTS[id];
+		AxolotlEntity.Variant variant = AxolotlEntity.Variant.byId(id);
 		MutableText text = Text.translatable("text.advancednbttooltip.tooltip.axolotl").formatted(Formatting.GRAY);
 		// Make sure we don't go out of bounds if mods add more axolotl types.
 		if (id < AXOLOTL_COLORS.length) {

--- a/src/main/java/me/b0iizz/advancednbttooltip/api/impl/builtin/IsItemCondition.java
+++ b/src/main/java/me/b0iizz/advancednbttooltip/api/impl/builtin/IsItemCondition.java
@@ -31,7 +31,7 @@ import net.minecraft.item.Item;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
+import net.minecraft.registry.Registries;
 
 /**
  * A condition which is fulfilled when the item is contained in the specified
@@ -51,7 +51,7 @@ public class IsItemCondition implements TooltipCondition {
 	@Override
 	public boolean isEnabled(Item item, NbtCompound tag, TooltipContext context) {
 		return items.getTooltipText(item, tag, context).stream().map(Text::getString).map(Identifier::new)
-				.map(Registry.ITEM::get).anyMatch(i -> item == i);
+				.map(Registries.ITEM::get).anyMatch(i -> item == i);
 	}
 
 }

--- a/src/main/java/me/b0iizz/advancednbttooltip/api/impl/builtin/ItemRendererFactory.java
+++ b/src/main/java/me/b0iizz/advancednbttooltip/api/impl/builtin/ItemRendererFactory.java
@@ -12,7 +12,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
+import net.minecraft.registry.Registries;
 
 import java.util.Collections;
 import java.util.List;
@@ -37,7 +37,7 @@ public class ItemRendererFactory implements TooltipFactory {
 	@Override
 	public List<TooltipComponent> getTooltip(Item item, NbtCompound tag, TooltipContext context) {
 		List<ItemStack> list = items.getTooltipText(item, tag, context).stream().map(Text::getString)
-				.map(Identifier::new).map(Registry.ITEM::get).distinct().map(ItemStack::new)
+				.map(Identifier::new).map(Registries.ITEM::get).distinct().map(ItemStack::new)
 				.toList();
 		return Collections.singletonList(new ItemTooltipComponent(list.toArray(ItemStack[]::new), width, scale));
 	}

--- a/src/main/java/me/b0iizz/advancednbttooltip/gui/CustomTooltipRenderer.java
+++ b/src/main/java/me/b0iizz/advancednbttooltip/gui/CustomTooltipRenderer.java
@@ -43,7 +43,7 @@ public interface CustomTooltipRenderer {
 	void renderComponents(MatrixStack matrices, @Nullable ItemStack stack, List<TooltipComponent> components, int x, int y);
 
 	default void renderTooltip(MatrixStack matrices, ItemStack stack, int x, int y, boolean advanced, @Nullable List<Text> vanilla_lines, @Nullable PlayerEntity player) {
-		TooltipContext ctx = advanced ? TooltipContext.Default.ADVANCED : TooltipContext.Default.NORMAL;
+		TooltipContext ctx = advanced ? TooltipContext.ADVANCED : TooltipContext.BASIC;
 		this.renderTooltip(matrices, stack, x, y, ctx, vanilla_lines, player);
 	}
 

--- a/src/main/java/me/b0iizz/advancednbttooltip/gui/HudTooltipRenderer.java
+++ b/src/main/java/me/b0iizz/advancednbttooltip/gui/HudTooltipRenderer.java
@@ -121,6 +121,10 @@ public class HudTooltipRenderer implements CustomTooltipRenderer {
 			return isAdvanced ? ADVANCED : NORMAL;
 		}
 
+		@Override
+		public boolean isCreative() {
+			return false;
+		}
 	}
 
 	/**

--- a/src/main/java/me/b0iizz/advancednbttooltip/gui/TooltipRenderingUtils.java
+++ b/src/main/java/me/b0iizz/advancednbttooltip/gui/TooltipRenderingUtils.java
@@ -28,7 +28,7 @@ import net.minecraft.client.gui.tooltip.TooltipComponent;
 import net.minecraft.client.render.*;
 import net.minecraft.client.render.item.ItemRenderer;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.util.math.Matrix4f;
+import org.joml.Matrix4f;
 
 import java.util.List;
 
@@ -38,7 +38,7 @@ public final class TooltipRenderingUtils {
 		matrices.push();
 		Tessellator tessellator = Tessellator.getInstance();
 		BufferBuilder bufferBuilder = tessellator.getBuffer();
-		RenderSystem.setShader(GameRenderer::getPositionColorShader);
+		RenderSystem.setShader(GameRenderer::getPositionColorProgram);
 		bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_COLOR);
 		Matrix4f modelMatrix = matrices.peek().getPositionMatrix();
 
@@ -81,7 +81,7 @@ public final class TooltipRenderingUtils {
 		RenderSystem.disableTexture();
 		RenderSystem.enableBlend();
 		RenderSystem.defaultBlendFunc();
-		BufferRenderer.drawWithShader(bufferBuilder.end());
+		BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
 		RenderSystem.disableBlend();
 		RenderSystem.enableTexture();
 		matrices.pop();

--- a/src/main/java/me/b0iizz/advancednbttooltip/gui/TooltipsScreen.java
+++ b/src/main/java/me/b0iizz/advancednbttooltip/gui/TooltipsScreen.java
@@ -68,15 +68,23 @@ public class TooltipsScreen extends Screen {
 	 * Initializes all widgets and buttons
 	 */
 	public void initWidgets() {
-		this.addDrawableChild(new ButtonWidget(width / 3, this.height - 27, this.width / 3, 20, Text.translatable("menu.returnToGame"), widget -> {
-			save();
-			this.client.setScreen(null);
-			this.client.mouse.lockCursor();
-		}));
-		this.addDrawableChild(new ButtonWidget(width * 9 / 12, this.height - 27, this.width / 6, 20, Text.translatable("text.autoconfig.advancednbttooltip.title"), widget -> {
-			save();
-			this.client.setScreen(ConfigManager.getConfigScreen(this).get());
-		}));
+		this.addDrawableChild(
+			new ButtonWidget.Builder(Text.translatable("menu.returnToGame"), widget -> {
+				save();
+				this.client.setScreen(null);
+				this.client.mouse.lockCursor();
+			})
+					.dimensions(width / 3, this.height - 27, this.width / 3, 20)
+					.build());
+
+		this.addDrawableChild(
+			new ButtonWidget.Builder(Text.translatable("text.autoconfig.advancednbttooltip.title"), widget -> {
+				save();
+				this.client.setScreen(ConfigManager.getConfigScreen(this).get());
+			})
+					.dimensions(width * 9 / 12, this.height - 27, this.width / 6, 20)
+					.build());
+
 		this.tooltipList = this.addDrawableChild(new TooltipListWidget(this.client, this, this.width, this.height, 40, this.height - 48, 20));
 	}
 
@@ -131,7 +139,11 @@ public class TooltipsScreen extends Screen {
 				this.widget = parent;
 				this.displayName = createDisplayName(id);
 				this.tooltip = createTooltip(id);
-				this.toggleButton = new ButtonWidget(0, 0, 35, 20, getText(ConfigManager.isEnabled(id)), button -> button.setMessage(getText(ConfigManager.toggle(id))));
+				this.toggleButton = new ButtonWidget.Builder(getText(ConfigManager.isEnabled(id)), button -> {
+					button.setMessage(getText(ConfigManager.toggle(id)));
+				})
+						.dimensions(0, 0, 35, 20)
+						.build();
 			}
 
 			private Text createDisplayName(Identifier id) {
@@ -170,8 +182,8 @@ public class TooltipsScreen extends Screen {
 
 				widget.client.textRenderer.draw(matrices, displayName, x, y + 5, 0xFFFFFF);
 
-				this.toggleButton.x = x + 190;
-				this.toggleButton.y = y;
+				this.toggleButton.setX(x + 190);
+				this.toggleButton.setY(y);
 
 				this.toggleButton.render(matrices, mouseX, mouseY, tickDelta);
 

--- a/src/main/java/me/b0iizz/advancednbttooltip/mixin/ScreenMixin.java
+++ b/src/main/java/me/b0iizz/advancednbttooltip/mixin/ScreenMixin.java
@@ -26,6 +26,8 @@ import me.b0iizz.advancednbttooltip.gui.CustomTooltipRenderer;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.tooltip.TooltipComponent;
+import net.minecraft.client.gui.tooltip.TooltipPositioner;
+import net.minecraft.client.gui.tooltip.HoveredTooltipPositioner;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
@@ -53,11 +55,11 @@ public abstract class ScreenMixin implements CustomTooltipRenderer {
 
 	@Override
 	public void renderComponents(MatrixStack matrices, ItemStack stack, List<TooltipComponent> components, int x, int y) {
-		this.renderTooltipFromComponents(matrices, components, x, y);
+		this.renderTooltipFromComponents(matrices, components, x, y, HoveredTooltipPositioner.INSTANCE);
 	}
 
 	@Shadow
 	protected abstract void renderTooltipFromComponents(MatrixStack matrices, List<TooltipComponent> components, int x,
-														int y);
+														int y, TooltipPositioner positioner);
 
 }

--- a/src/main/resources/advancednbttooltip.mixins.json
+++ b/src/main/resources/advancednbttooltip.mixins.json
@@ -7,8 +7,9 @@
   ],
   "client": [
   	"EnchantmentMixin",
-    "ItemStackMixin",
-    "ScreenMixin"
+	"ItemStackMixin",
+	"ScreenMixin",
+	"CreativeInventoryScreenMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/advancednbttooltip.mixins.json
+++ b/src/main/resources/advancednbttooltip.mixins.json
@@ -7,9 +7,8 @@
   ],
   "client": [
   	"EnchantmentMixin",
-	"ItemStackMixin",
-	"ScreenMixin",
-	"CreativeInventoryScreenMixin"
+    "ItemStackMixin",
+    "ScreenMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,7 +33,7 @@
 	"depends": {
 		"fabricloader": ">=0.7.4",
 		"fabric": "*",
-		"minecraft": "1.19.x"
+		"minecraft": "1.19.3"
 	},
 	"suggests": {
 		"modmenu": "*",


### PR DESCRIPTION
The code is updated to ensure compatibility with the game version 1.19.3 with mappings 1.19.3+build.5. Builds should pass and run flawlessly with the game.

The `CreativeInventoryScreenMixin` is temporarily disabled by me, because it causes a crash upon inventory/chest opening. Currently I have no solution to this, for there is no change between 1.19+build.2 and 1.19.3+build.5 in the modded class itself. Suggestions are welcome.